### PR TITLE
Add flag to include un-tracked files

### DIFF
--- a/git-infer
+++ b/git-infer
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 
+only_staged="only-staged"
+all_tracked="all-only-tracked"
+all_untracked="all-include-untracked"
+
 COMMAND="git diff --staged --name-status"
-TYPE=0
+TYPE=$only_staged
  
-while getopts ":an" opt; do
+while getopts ":aA" opt; do
   case $opt in
     a)
       COMMAND="git status --porcelain -uno"
-      TYPE=1
+      TYPE=$all_tracked
       ;;
-    n)
+    A)
       COMMAND="git status --porcelain -uall"
-      TYPE=2
+      TYPE=$all_untracked
       ;;
   esac
 done
@@ -58,6 +62,20 @@ END {
     addedMsg = "Add " addedMsg
   }
 
+  if (newCount > 0) {
+    newMsg = "";
+    for (i = 0; i + 1 < newCount; i++) {
+      newMsg = newMsg new[i] ", "
+    };
+    newMsg = newMsg new[newCount - 1]
+
+    if (addedCount > 0) {
+      addedMsg = addedMsg ", " newMsg
+    } else {
+      addedMsg = "Add " newMsg
+    };
+  }
+
   if (deletedCount > 0) {
     deletedMsg = "";
     for (i = 0; i + 1 < deletedCount; i++) {
@@ -67,30 +85,17 @@ END {
     deletedMsg = "Delete " deletedMsg
   }
 
-  if (newCount >0) {
-    newMsg = "";
-    for (i = 0; i + 1 < newCount; i++) {
-      newMsg = newMsg new[i] ", "
-    };
-    newMsg = newMsg new[newCount - 1]
-    newMsg = "New tracked files " newMsg
-  }
-
   changesCount = 0;
 
   if (updatedCount > 0) {
     changesCount += 1
   }
 
-  if (addedCount > 0) {
+  if (addedCount > 0 || newCount > 0) {
     changesCount += 1
   }
 
   if (deletedCount > 0) {
-    changesCount += 1
-  }
-
-  if (newCount > 0) {
     changesCount += 1
   }
 
@@ -101,16 +106,12 @@ END {
       print updatedMsg
     }
 
-    if (addedCount > 0) {
+    if (addedCount > 0 || newCount > 0) {
       print addedMsg
     }
 
     if (deletedCount > 0) {
       print deletedMsg
-    }
-
-    if (newCount > 0) {
-      print newMsg
     }
   }
 
@@ -119,16 +120,12 @@ END {
       print updatedMsg
     }
 
-    if (addedCount > 0) {
+    if (addedCount > 0 || newCount > 0) {
       print addedMsg
     }
 
     if (deletedCount > 0) {
       print deletedMsg
-    }
-
-    if (newCount > 0) {
-      print newMsg
     }
   }
 }
@@ -140,12 +137,13 @@ then
   exit 1
 fi
 
-if [ "$TYPE" -eq "1" ];then
+if [ "$TYPE" = "$all_tracked" ];then
   git add -u;
 fi
 
-if [ "$TYPE" -eq "2" ];then
+if [ "$TYPE" = "$all_untracked" ];then
   git add .;
 fi
 
-git commit -m "${COMMIT_MSG}" "$@"
+# -A is is not recognized by `git commit` - needs to be removed
+git commit -m "${COMMIT_MSG}" "${@//"-A"}"

--- a/git-infer
+++ b/git-infer
@@ -25,23 +25,18 @@ BEGIN {
   updatedCount = 0;
   addedCount = 0;
   deletedCount = 0;
-  newCount = 0;
 }
 $1 == "M" {
   updated[updatedCount] = $2;
   updatedCount += 1
 }
-$1 == "A" {
+$1 == "A" || $1 == "??" {
   added[addedCount] = $2;
   addedCount += 1
 }
 $1 == "D" {
   deleted[deletedCount] = $2;
   deletedCount += 1
-}
-$1 == "??" {
-  new[newCount] = $2;
-  newCount += 1
 }
 END {
   if (updatedCount > 0) {
@@ -62,20 +57,6 @@ END {
     addedMsg = "Add " addedMsg
   }
 
-  if (newCount > 0) {
-    newMsg = "";
-    for (i = 0; i + 1 < newCount; i++) {
-      newMsg = newMsg new[i] ", "
-    };
-    newMsg = newMsg new[newCount - 1]
-
-    if (addedCount > 0) {
-      addedMsg = addedMsg ", " newMsg
-    } else {
-      addedMsg = "Add " newMsg
-    };
-  }
-
   if (deletedCount > 0) {
     deletedMsg = "";
     for (i = 0; i + 1 < deletedCount; i++) {
@@ -91,7 +72,7 @@ END {
     changesCount += 1
   }
 
-  if (addedCount > 0 || newCount > 0) {
+  if (addedCount > 0) {
     changesCount += 1
   }
 
@@ -106,7 +87,7 @@ END {
       print updatedMsg
     }
 
-    if (addedCount > 0 || newCount > 0) {
+    if (addedCount > 0) {
       print addedMsg
     }
 
@@ -120,7 +101,7 @@ END {
       print updatedMsg
     }
 
-    if (addedCount > 0 || newCount > 0) {
+    if (addedCount > 0) {
       print addedMsg
     }
 
@@ -145,5 +126,4 @@ if [ "$TYPE" = "$all_untracked" ];then
   git add .;
 fi
 
-# -A is is not recognized by `git commit` - needs to be removed
-git commit -m "${COMMIT_MSG}" "${@//"-A"}"
+git commit -m "${COMMIT_MSG}"

--- a/git-infer
+++ b/git-infer
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 
 COMMAND="git diff --staged --name-status"
+TYPE=0
  
-while getopts ":a" opt; do
+while getopts ":an" opt; do
   case $opt in
     a)
       COMMAND="git diff --name-status"
+      TYPE=1
+      ;;
+    n)
+      COMMAND="git status --porcelain"
+      TYPE=2
       ;;
   esac
 done
@@ -15,23 +21,24 @@ BEGIN {
   updatedCount = 0;
   addedCount = 0;
   deletedCount = 0;
+  newCount = 0;
 }
-
 $1 == "M" {
   updated[updatedCount] = $2;
   updatedCount += 1
 }
-
 $1 == "A" {
   added[addedCount] = $2;
   addedCount += 1
 }
-
 $1 == "D" {
   deleted[deletedCount] = $2;
   deletedCount += 1
 }
-
+$1 == "??" {
+  new[newCount] = $2;
+  newCount += 1
+}
 END {
   if (updatedCount > 0) {
     updatedMsg = "";
@@ -60,14 +67,69 @@ END {
     deletedMsg = "Delete " deletedMsg
   }
 
+  if (newCount >0) {
+    newMsg = "";
+    for (i = 0; i + 1 < newCount; i++) {
+      newMsg = newMsg new[i] ", "
+    };
+    newMsg = newMsg new[newCount - 1]
+    newMsg = "New tracked files " newMsg
+  }
+
+  changesCount = 0;
+
   if (updatedCount > 0) {
-    print updatedMsg
+    changesCount += 1
   }
+
   if (addedCount > 0) {
-    print addedMsg
+    changesCount += 1
   }
+
   if (deletedCount > 0) {
-    print deletedMsg
+    changesCount += 1
+  }
+
+  if (newCount > 0) {
+    changesCount += 1
+  }
+
+  if (changesCount > 1) {
+    printf "Several changes\n\n"
+
+    if (updatedCount > 0) {
+      print updatedMsg
+    }
+
+    if (addedCount > 0) {
+      print addedMsg
+    }
+
+    if (deletedCount > 0) {
+      print deletedMsg
+    }
+
+    if (newCount > 0) {
+      print newMsg
+    }
+  }
+
+  if (changesCount == 1) {
+    if (updatedCount > 0) {
+      print updatedMsg
+    }
+
+    if (addedCount > 0) {
+      print addedMsg
+    }
+
+    if (deletedCount > 0) {
+      print deletedMsg
+    }
+
+    if (newCount > 0) {
+      print newMsg
+    }
   }
 }
 ')
@@ -76,6 +138,14 @@ if [ -z "${COMMIT_MSG}" ]
 then
   echo "git-infer: Nothing added, updated or deleted"
   exit 1
+fi
+
+if [ "$TYPE" -eq "1" ];then
+  git add -u;
+fi
+
+if [ "$TYPE" -eq "2" ];then
+  git add .;
 fi
 
 git commit -m "${COMMIT_MSG}" "$@"

--- a/git-infer
+++ b/git-infer
@@ -6,11 +6,11 @@ TYPE=0
 while getopts ":an" opt; do
   case $opt in
     a)
-      COMMAND="git diff --name-status"
+      COMMAND="git status --porcelain -uno"
       TYPE=1
       ;;
     n)
-      COMMAND="git status --porcelain"
+      COMMAND="git status --porcelain -uall"
       TYPE=2
       ;;
   esac


### PR DESCRIPTION
Added flag `-A` to include un-tracked files.

Also:

- Stop forwarding arguments to `git commit`
- Updated message when there are several types of changes, since the second line of commit messages should be empty.

Before:
```
Update readme.md
Remove foo.md, bar.md
```

Now:
```
Several changes

Update readme.md
Remove foo.md
```



Is the first time I use awk so I know the code could be improved :sweat_smile: 